### PR TITLE
Return value from assertions with let expressions.

### DIFF
--- a/assert2-macros/src/let_placeholder.rs
+++ b/assert2-macros/src/let_placeholder.rs
@@ -1,0 +1,84 @@
+extern crate proc_macro;
+
+use proc_macro::Group;
+use proc_macro::Ident;
+use proc_macro::Punct;
+use proc_macro::TokenStream;
+use proc_macro::TokenTree;
+
+#[derive(Debug)]
+pub struct Placeholder {
+	pub original: Punct,
+	pub replacement: Ident,
+}
+
+struct Replacer {
+	placeholder: Option<Placeholder>,
+}
+
+impl Replacer {
+	fn new() -> Self {
+		Self { placeholder: None }
+	}
+
+	fn visit_stream(&mut self, stream: TokenStream) -> syn::Result<TokenStream> {
+		let mut result = TokenStream::new();
+		for tree in stream.into_iter() {
+			result.extend(std::iter::once(self.visit_tree(tree)?));
+		}
+		Ok(result)
+	}
+
+	fn visit_tree(&mut self, tree: TokenTree) -> syn::Result<TokenTree> {
+		match tree {
+			TokenTree::Group(x)   => self.visit_group(x),
+			TokenTree::Ident(x)   => Ok(TokenTree::Ident(x)),
+			TokenTree::Punct(x)   => self.visit_punct(x),
+			TokenTree::Literal(x) => Ok(TokenTree::Literal(x)),
+		}
+	}
+
+	fn visit_group(&mut self, group: Group) -> syn::Result<TokenTree> {
+		let stream = self.visit_stream(group.stream())?;
+		let mut result = Group::new(group.delimiter(), stream);
+		result.set_span(group.span());
+		Ok(TokenTree::Group(result))
+	}
+
+	fn visit_punct(&mut self, punct: Punct) -> syn::Result<TokenTree> {
+		if punct.as_char() != '#' {
+			Ok(TokenTree::Punct(punct))
+		} else if self.placeholder.is_some() {
+			Err(syn::Error::new(punct.span().into(), "found multiple placeholders in pattern"))
+		} else {
+			// TODO: punct.span() should be def_site().located_at(punct) once stabilized.
+			// Currently, our placeholder can conflict with other placeholders in the pattern.
+			let replacement = Ident::new("__ret", punct.span());
+			self.placeholder = Some(Placeholder {
+				original: punct,
+				replacement: replacement.clone(),
+			});
+
+			Ok(TokenTree::Ident(replacement))
+		}
+	}
+}
+
+pub fn replace_let_placeholder(stream: TokenStream) -> syn::Result<(TokenStream, Option<Placeholder>)> {
+	// Look at the third token to check if this is a let expression.
+	// Macro starts with the macro name and a comma, so third token tree is the start of the expression.
+	let first_token = stream.clone().into_iter().skip(2).next();
+	let is_let_expr = match first_token {
+		Some(TokenTree::Ident(x)) => x.to_string() == "let",
+		_ => false,
+	};
+
+	// If it is, replace `#` with a placeholder to be returned.
+	if is_let_expr {
+		let mut replacer = Replacer::new();
+		let stream = replacer.visit_stream(stream)?;
+		Ok((stream, replacer.placeholder))
+	} else {
+		Ok((stream, None))
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,9 @@ pub use assert2_macros::check_impl;
 #[macro_export]
 macro_rules! assert {
 	($($tokens:tt)*) => {
-		if let Err(()) = ::assert2::check_impl!("assert", $($tokens)*) {
-			panic!("assertion failed");
+		match ::assert2::check_impl!("assert", $($tokens)*) {
+			Ok(x) => x,
+			Err(()) => panic!("assertion failed"),
 		}
 	}
 }

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -41,6 +41,15 @@ fn debug_assert_pass() {
 	debug_assert!(let Ok(10) = Result::<i32, i32>::Ok(10), "{}", "rust broke",);
 }
 
+#[test]
+fn assert_return_value() {
+	let x = assert!(let Some(#) = Some(10));
+	check!(x == 10);
+
+	let x = assert!(let (#, 2) = (1, 2));
+	check!(x == 1);
+}
+
 #[derive(Eq, PartialEq, Ord, PartialOrd)]
 struct I(i32);
 


### PR DESCRIPTION
This PR adds the option to put a placeholder in a `let` pattern which will be returned from `assert!()`.

For example:
```rust
let foo = assert!(let Ok(#) = Foo::try_new("aap"));
check!(foo.bar() == "noot");
check!(foo.baz() == "mies");
```

The same doesn't work with `check!()` right now, since it doesn't directly panic if the check fails. We could make it return an option, but I'm not sure if there are really use cases for that. Can be added later too if it turns out there is a demand for it.

I'm not entirely sure on the syntax yet. All alternatives below have the advantage that they can capture multiple variables. I imagine that capturing a single variable is the most common use case, but it's still a nice property.

```rust
// Actual rust syntax, but verbose, and an if in an assert looks weird.
let foo = assert!(if let Ok(x) = Foo::try_new("aap") { x });

// Simply drop the if: shorter, but weird. I don't really like the braces.
let foo = assert!(let Ok(x) = Foo::try_new("aap") { x });

// Smush together match and let, sort of. Also weird.
let foo = assert!(let Ok(x) = Foo::try_new("aap") => x);
let foo = assert!(match Ok(x) = Foo::try_new("aap") => x);

// Departing even further from normal syntax.
let foo = assert!(x in let Ok(x) = Foo::try_new("aap"));

// Other options?
```

Also, on stable you currently see the stringification with the `#` replaced by `__ret`. The alternatives above wouldn't suffer from that problem.

`__ret` even conflicts with other placeholders in the pattern because all spans available without nightly features resolve at the call site.

With `proc_macro_hygiene` it's probably possible to make all placeholders visible outside of the assert without additional syntax. But I don't think that can be done with `proc_macro_hack`.

Feedback and discussion welcome :)