### PR TITLE
Add `let_assert` macro.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,12 +4,17 @@ on:
   pull_request: { branches: "*" }
 
 jobs:
-  build_and_test:
-    name: Build and test
+  nightly:
+    name: Build and test on nightly with all features
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@master
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -20,3 +25,25 @@ jobs:
         with:
           command: test
           args: --release --all-features --color=always
+
+  stable:
+    name: Build and test on stable without features
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --color=always
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --color=always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,12 @@ categories = ["development-tools::debugging", "development-tools::testing"]
 
 [features]
 let-assert = ["assert2-macros/let-assert"]
+doc-cfg = []
 
 [dependencies]
 assert2-macros = { version = "=0.1.0", path = "assert2-macros" }
 proc-macro-hack = "0.5.11"
 yansi = "0.5.0"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ readme = "README.md"
 keywords = ["assert", "check", "test", "unit-test"]
 categories = ["development-tools::debugging", "development-tools::testing"]
 
+[features]
+let-assert = ["assert2-macros/let-assert"]
+
 [dependencies]
 assert2-macros = { version = "=0.1.0", path = "assert2-macros" }
 proc-macro-hack = "0.5.11"

--- a/assert2-macros/Cargo.toml
+++ b/assert2-macros/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 repository = "https://github.com/de-vri-es/assert2-rs"
 documentation = "https://docs.rs/assert2"
 
+[features]
+let-assert = ["syn/visit"]
+
 [lib]
 proc-macro = true
 

--- a/assert2-macros/src/let_assert.rs
+++ b/assert2-macros/src/let_assert.rs
@@ -1,0 +1,134 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::punctuated::Punctuated;
+
+use crate::spanned_to_string;
+use crate::FormatArgs;
+
+pub struct Args {
+	macro_name: syn::Expr,
+	pattern: syn::Pat,
+	eq_token: syn::token::Eq,
+	expression: syn::Expr,
+	format_args: Option<FormatArgs>,
+}
+
+pub fn let_assert_impl(args: Args) -> TokenStream {
+	let Args {
+		macro_name,
+		pattern,
+		eq_token,
+		expression,
+		format_args,
+	} = args;
+
+	let placeholders = collect_placeholders(&pattern);
+
+	let mut use_placeholders = TokenStream::new();
+	for placeholder in &placeholders {
+		use_placeholders.extend(quote! {
+			&#placeholder,
+		});
+	}
+	let use_placeholders = quote! {
+		let _ = (#use_placeholders);
+	};
+
+	let placeholders = puncuate_idents(placeholders);
+
+	let pat_str = spanned_to_string(&pattern);
+	let expr_str = spanned_to_string(&expression);
+	let custom_msg = match format_args {
+		Some(x) => quote!(Some(format_args!(#x))),
+		None => quote!(None),
+	};
+
+	quote! {
+		let (#placeholders) = {
+			let value = #expression;
+			if let #pattern #eq_token &value {
+				#use_placeholders
+				if let #pattern #eq_token value {
+					(#placeholders)
+				} else {
+					panic!("{}: second pattern match failed, please report this at https://github.com/de-vri-es/assert2-rs/issues/new/");
+				}
+			} else {
+				#[allow(unused)]
+				use ::assert2::maybe_debug::{IsDebug, IsMaybeNotDebug};
+				let value = (&&::assert2::maybe_debug::Wrap(&value)).__assert2_maybe_debug().wrap(&value);
+				::assert2::print::FailedCheck {
+					macro_name: #macro_name,
+					file: file!(),
+					line: line!(),
+					column: column!(),
+					custom_msg: #custom_msg,
+					expression: ::assert2::print::MatchExpr {
+						value: &value,
+						pattern: #pat_str,
+						expression: #expr_str,
+					}
+				}.print();
+				panic!("assertion failed");
+			}
+		};
+	}
+}
+
+struct CollectPlaceholders<'a> {
+	placeholders: &'a mut Vec<syn::Ident>,
+}
+
+impl<'a> CollectPlaceholders<'a> {
+	fn new(placeholders: &'a mut Vec<syn::Ident>) -> Self {
+		Self { placeholders }
+	}
+}
+
+impl<'a> syn::visit::Visit<'a> for CollectPlaceholders<'_> {
+	fn visit_pat_ident(&mut self, pat_ident: &'a syn::PatIdent) {
+		self.placeholders.push(pat_ident.ident.clone());
+	}
+}
+
+fn collect_placeholders(pat: &syn::Pat) -> Vec<syn::Ident> {
+	use syn::visit::Visit;
+	let mut placeholders = Vec::new();
+	let mut collector = CollectPlaceholders::new(&mut placeholders);
+	collector.visit_pat(pat);
+	placeholders
+}
+
+fn puncuate_idents(input: impl IntoIterator<Item = syn::Ident>) -> Punctuated<syn::Ident, syn::token::Comma> {
+	let mut punctuated: Punctuated<syn::Ident, syn::token::Comma> = input.into_iter().collect();
+	if !punctuated.is_empty() {
+		punctuated.push_punct(syn::token::Comma::default());
+	}
+	punctuated
+}
+
+impl syn::parse::Parse for Args {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let macro_name = input.parse()?;
+		let _comma = input.parse::<syn::token::Comma>()?;
+		let pattern = input.parse()?;
+		let eq_token = input.parse()?;
+		let expression = input.parse()?;
+
+		let format_args = if input.is_empty() {
+			FormatArgs::new()
+		} else {
+			input.parse::<syn::token::Comma>()?;
+			FormatArgs::parse_terminated(input)?
+		};
+		let format_args = Some(format_args).filter(|x| !x.is_empty());
+
+		Ok(Self {
+			macro_name,
+			pattern,
+			eq_token,
+			expression,
+			format_args,
+		})
+	}
+}

--- a/assert2-macros/src/let_assert.rs
+++ b/assert2-macros/src/let_assert.rs
@@ -59,18 +59,18 @@ pub fn let_assert_impl(args: Args) -> TokenStream {
 	}
 }
 
-#[derive(Default)]
-struct CollectPlaceholders {
-	placeholders: Vec<syn::Ident>,
-}
-
-impl<'a> syn::visit::Visit<'a> for CollectPlaceholders {
-	fn visit_pat_ident(&mut self, pat_ident: &'a syn::PatIdent) {
-		self.placeholders.push(pat_ident.ident.clone());
-	}
-}
-
 fn collect_placeholders(pat: &syn::Pat) -> Punctuated<syn::Ident, syn::token::Comma> {
+	#[derive(Default)]
+	struct CollectPlaceholders {
+		placeholders: Vec<syn::Ident>,
+	}
+
+	impl<'a> syn::visit::Visit<'a> for CollectPlaceholders {
+		fn visit_pat_ident(&mut self, pat_ident: &'a syn::PatIdent) {
+			self.placeholders.push(pat_ident.ident.clone());
+		}
+	}
+
 	use syn::visit::Visit;
 	let mut collector = CollectPlaceholders::default();
 	collector.visit_pat(pat);

--- a/assert2-macros/src/let_assert.rs
+++ b/assert2-macros/src/let_assert.rs
@@ -47,6 +47,7 @@ pub fn let_assert_impl(args: Args) -> TokenStream {
 					column: column!(),
 					custom_msg: #custom_msg,
 					expression: ::assert2::print::MatchExpr {
+						print_let: false,
 						value: &value,
 						pattern: #pat_str,
 						expression: #expr_str,

--- a/assert2-macros/src/lib.rs
+++ b/assert2-macros/src/lib.rs
@@ -150,6 +150,7 @@ fn check_let_expr(macro_name: syn::Expr, expr: syn::ExprLet, format_args: Option
 					column: column!(),
 					custom_msg: #custom_msg,
 					expression: ::assert2::print::MatchExpr {
+						print_let: true,
 						value: &value,
 						pattern: #pat_str,
 						expression: #expr_str,

--- a/assert2-macros/src/lib.rs
+++ b/assert2-macros/src/lib.rs
@@ -18,6 +18,16 @@ pub fn check_impl(tokens: TokenStream) -> TokenStream {
 	check_or_assert_impl(syn::parse_macro_input!(tokens)).into()
 }
 
+#[cfg(feature = "let-assert")]
+mod let_assert;
+
+#[cfg(feature = "let-assert")]
+#[proc_macro]
+#[doc(hidden)]
+pub fn let_assert_impl(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let_assert::let_assert_impl(syn::parse_macro_input!(tokens)).into()
+}
+
 /// Real implementation for assert!() and check!().
 fn check_or_assert_impl(args: Args) -> proc_macro2::TokenStream {
 	match args.expr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! # The `let_assert!()` macro
 //! If you enable the `let-assert` feature of the crate,
 //! and the unstable `proc_macro_hygiene` feature,
-//! you can also use an additional macro: `let_assert!(...)`.
+//! you can also use an additional macro: [`let_assert!(...)`](macro.let_assert.html).
 //! This is very similar to an `assert` with a `let` statement,
 //! except that all placeholders will be made available as variables in the calling scope.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,14 @@ macro_rules! debug_assert {
 	}
 }
 
+#[cfg(feature = "let-assert")]
+#[macro_export]
+macro_rules! let_assert {
+	($($tokens:tt)*) => {
+		::assert2_macros::let_assert_impl!("let_assert", $($tokens)*);
+	}
+}
+
 #[doc(hidden)]
 pub mod maybe_debug;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "doc-cfg", feature(doc_cfg))]
 #![allow(clippy::needless_lifetimes)]
 
 //! All-purpose [`assert!(...)`](macro.assert.html) and [`check!(...)`](macro.check.html) macros, inspired by [Catch2](https://github.com/catchorg/Catch2).
@@ -59,8 +60,68 @@
 //! # Difference between stable and nightly.
 //! If available, the crate uses the `proc_macro_span` feature to get the original source code.
 //! On stable and beta, it falls back to stringifying the expression.
-//! This makes the output a bit more readable on nightly,
-//! but the differences are limited to the displayed expression.
+//! This makes the output a bit more readable on nightly.
+//!
+//! # The `let_assert!()` macro
+//! If you enable the `let-assert` feature of the crate,
+//! and the unstable `proc_macro_hygiene` feature,
+//! you can also use an additional macro: `let_assert!(...)`.
+//! This is very similar to an `assert` with a `let` statement,
+//! except that all placeholders will be made available as variables in the calling scope.
+//!
+//! This allows you to run additional checks on the captured variables.
+//! For example:
+//!
+//! ```
+//! # // This may look weird, but it makes sures the code looks as it should on nightly,
+//! # // but and compiles into a NOP if the "let_assert" feature is off for stable.
+//! # #![cfg_attr(feature = "let_assert", feature(proc_macro_hygiene))]
+//! # #[cfg(feature = "let_assert")] {
+//! #![feature(proc_macro_hygiene)]
+//! # }
+//!
+//! # #[cfg(feature = "let_assert")]
+//! # fn main() {
+//! # use assert2::let_assert;
+//! # use assert2::check;
+//! # struct Foo {
+//! #  name: &'static str,
+//! # }
+//! # enum Error {
+//! #   InvalidName(InvalidNameError),
+//! # }
+//! # struct InvalidNameError {
+//! #   name: &'static str,
+//! # }
+//! # impl Foo {
+//! #   fn try_new(name: &'static str) -> Result<Self, Error> {
+//! #     if name == "bar" {
+//! #       Ok(Self { name })
+//! #     } else {
+//! #       Err(Error::InvalidName(InvalidNameError { name }))
+//! #     }
+//! #   }
+//! #   fn name(&self) -> &'static str {
+//! #     self.name
+//! #   }
+//! # }
+//! # impl InvalidNameError {
+//! #   fn name(&self) -> &'static str {
+//! #     self.name
+//! #   }
+//! #   fn to_string(&self) -> String {
+//! #     format!("invalid name: {}", self.name)
+//! #   }
+//! # }
+//! let_assert!(Ok(foo) = Foo::try_new("bar"));
+//! check!(foo.name() == "bar");
+//!
+//! let_assert!(Err(Error::InvalidName(e)) = Foo::try_new("bogus name"));
+//! check!(e.name() == "bogus name");
+//! check!(e.to_string() == "invalid name: bogus name");
+//! # }
+//! ```
+//!
 //!
 //! # Controlling colored output.
 //!
@@ -154,7 +215,62 @@ macro_rules! debug_assert {
 	}
 }
 
+/// Assert that an expression matches a pattern.
+///
+/// This is very similar to `assert!(let pattern = expression)`,
+/// except that this macro makes all placeholders available in the calling scope.
+/// This can be used to assert a pattern match,
+/// and then run more checks on the captured variables.
+///
+/// This macro is only available if if the `let-assert` feature of the `assert2` crate is enabled,
+/// and it requires the `proc_macro_hygiene` rust feature to be enabled by the user of the macro.
+///
+/// For example:
+/// ```
+/// #![feature(proc_macro_hygiene)]
+///
+/// # use assert2::let_assert;
+/// # use assert2::check;
+/// # fn main() {
+/// # struct Foo {
+/// #  name: &'static str,
+/// # }
+/// # enum Error {
+/// #   InvalidName(InvalidNameError),
+/// # }
+/// # struct InvalidNameError {
+/// #   name: &'static str,
+/// # }
+/// # impl Foo {
+/// #   fn try_new(name: &'static str) -> Result<Self, Error> {
+/// #     if name == "bar" {
+/// #       Ok(Self { name })
+/// #     } else {
+/// #       Err(Error::InvalidName(InvalidNameError { name }))
+/// #     }
+/// #   }
+/// #   fn name(&self) -> &'static str {
+/// #     self.name
+/// #   }
+/// # }
+/// # impl InvalidNameError {
+/// #   fn name(&self) -> &'static str {
+/// #     self.name
+/// #   }
+/// #   fn to_string(&self) -> String {
+/// #     format!("invalid name: {}", self.name)
+/// #   }
+/// # }
+/// let_assert!(Ok(foo) = Foo::try_new("bar"));
+/// check!(foo.name() == "bar");
+///
+/// let_assert!(Err(Error::InvalidName(e)) = Foo::try_new("bogus name"));
+/// check!(e.name() == "bogus name");
+/// check!(e.to_string() == "invalid name: bogus name");
+/// # }
+/// ```
 #[cfg(feature = "let-assert")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(all(feature = "let-assert", proc_macro_hygiene))))]
 #[macro_export]
 macro_rules! let_assert {
 	($($tokens:tt)*) => {

--- a/src/print.rs
+++ b/src/print.rs
@@ -74,6 +74,7 @@ pub struct BooleanExpr<'a> {
 }
 
 pub struct MatchExpr<'a, Value> {
+	pub print_let: bool,
 	pub value: &'a Value,
 	pub pattern: &'a str,
 	pub expression: &'a str,
@@ -138,8 +139,10 @@ impl CheckExpression for BooleanExpr<'_> {
 #[rustfmt::skip]
 impl<Value: Debug> CheckExpression for MatchExpr<'_, Value> {
 	fn print_expression(&self) {
-		eprint!("{let_} {pat} {eq} {expr}",
-			let_ = Paint::blue("let").bold(),
+		if self.print_let {
+			eprint!("{} ", Paint::blue("let").bold());
+		}
+		eprint!("{pat} {eq} {expr}",
 			pat  = Paint::cyan(self.pattern),
 			eq   = Paint::blue("=").bold(),
 			expr = Paint::yellow(self.expression),

--- a/tests/let_assert.rs
+++ b/tests/let_assert.rs
@@ -1,0 +1,60 @@
+#![cfg_attr(feature = "let-assert", feature(proc_macro_hygiene))]
+
+#[cfg(feature = "let-assert")]
+mod tests {
+	use assert2::assert;
+	use assert2::let_assert;
+
+	#[test]
+	fn basic_match() {
+		// Test a basic match.
+		let_assert!(Some(x) = Some(10));
+		assert!(x == 10);
+	}
+
+	#[test]
+	fn basic_match_ref() {
+		// Test a basic match on a reference.
+		let_assert!(Some(x) = &Some(10));
+		assert!(x == &10);
+	}
+
+	#[test]
+	fn anonymous_placeholders() {
+		// Make sure _ placeholders are ignored.
+		let_assert!((_, _, _) = (10, 11, 12));
+		let_assert!((x, _, y) = (13, 14, 15));
+		assert!(x == 13);
+		assert!(y == 15);
+	}
+
+	#[test]
+	fn underscore_prefixed_placeholders() {
+		// But _name placeholders are not ignored.
+		let_assert!((_x, _, _y) = (13, 14, 15));
+		assert!(_x == 13);
+		assert!(_y == 15);
+	}
+
+	#[test]
+	fn consume() {
+		let_assert!(Some(x) = Some(String::from("foo")));
+		assert!(x == "foo");
+	}
+
+	macro_rules! test_panic {
+		($name:ident, $($expr:tt)*) => {
+			#[test]
+			#[should_panic]
+			fn $name() {
+				$($expr)*;
+			}
+		}
+	}
+
+	test_panic!(panic_let_assert1, let_assert!(Ok(_x) = Result::<i32, i32>::Err(10)));
+	test_panic!(
+		panic_let_assert2,
+		let_assert!(Ok(_x) = Result::<i32, i32>::Err(10), "{}", "rust broke")
+	);
+}


### PR DESCRIPTION
This PR adds a `let_assert` macro (feature gated behind "let_assert"). It is also only usable on nightly, as it needs `proc_macro_hygiene`.

The macro is very similar to `assert!(let pat = expr)`, except that all placeholders are made available as variables in the calling scope.

This is meant to replace #9.

@m-ou-se: Do you have time to review the PR?

Usage should be like this:
```rust
#![feature(proc_macro_hygiene)]

let_assert!(Ok(foo) = Foo::try_new("bar"));
check!(foo.name() == "bar");

let_assert!(Err(Error::InvalidName(e)) = Foo::try_new("bogus name"));
check!(e.name() == "bogus name");
check!(e.to_string() == "invalid name: bogus name");
```