### PR TITLE
Rename exported hidden macro, and hygienically use core::stringify.

### DIFF
--- a/assert2-macros/src/lib.rs
+++ b/assert2-macros/src/lib.rs
@@ -185,7 +185,7 @@ fn expression_to_string(crate_name: &syn::Path, ts: TokenStream, fragments: &mut
 
 	let _ = fragments;
 
-	quote!(#crate_name::stringify!(#ts))
+	quote!(#crate_name::__assert2_stringify!(#ts))
 }
 
 #[cfg(nightly)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,16 +281,19 @@ macro_rules! let_assert {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! stringify {
+macro_rules! __assert2_stringify {
 	($e:expr) => {
 		// Stringifying as an expression gives nicer output
 		// than stringifying a raw list of token trees.
-		stringify!($e)
+		$crate::__assert2_core_stringify!($e)
 	};
 	($($t:tt)*) => {
-		stringify!($($t)*)
+		$crate::__assert2_core_stringify!($($t)*)
 	};
 }
+
+#[doc(hidden)]
+pub use core::stringify as __assert2_core_stringify;
 
 #[doc(hidden)]
 pub mod maybe_debug;


### PR DESCRIPTION
Fixes #19.

Still needs a test.