### PR TITLE
fix isatty dependency failing to link on windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   nightly:
     name: Build and test on nightly with all features
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -28,7 +31,10 @@ jobs:
 
   stable:
     name: Build and test on stable without features
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+      runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-      runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /Cargo.lock
+
+# Intellij Idea IDE settings folder
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ categories = ["development-tools::debugging", "development-tools::testing"]
 [dependencies]
 assert2-macros = { version = "=0.3.4", path = "assert2-macros" }
 yansi = "0.5.0"
+atty = "0.2.14"

--- a/src/__assert2_impl/print.rs
+++ b/src/__assert2_impl/print.rs
@@ -1,15 +1,8 @@
 use std::os::raw::c_int;
 use yansi::Paint;
+use atty::Stream;
 
 use std::fmt::Debug;
-
-extern "C" {
-	fn isatty(fd: c_int) -> c_int;
-}
-
-fn stderr_is_tty() -> bool {
-	unsafe { isatty(2) != 0 }
-}
 
 fn should_color() -> bool {
 	if std::env::var_os("CLICOLOR").map(|x| x == "0").unwrap_or(false) {
@@ -17,7 +10,7 @@ fn should_color() -> bool {
 	} else if std::env::var_os("CLICOLOR_FORCE").map(|x| x != "0").unwrap_or(false) {
 		true
 	} else {
-		stderr_is_tty()
+		atty::is(Stream::Stderr)
 	}
 }
 


### PR DESCRIPTION
This change does two things:

1. Update the CI build to use a multi-platform strategy based build, so we can check functionality on window, linux, and macos.
2. Remove the isatty c binding and replace it with the [atty](https://crates.io/crates/atty) crate to allow for easy crossplatform integration.