### PR TITLE
Show diffs when a binary comparison fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
+main:
+  * Automatically choose between pretty or compact `Debug` output, unless overridden.
+  * Print a diff for failed binary comparisons.
+  * Allow end-users to change the output of `assert2` with the `ASSERT2` environment variable.
+  * Support the `NO_COLOR` environment variable in addition to `CLICOLOR`.
+
 v0.3.11 - 2023-05-24:
-  * Remove use of `source_text()` on stable since current it gives the source text of only one token tree.
+  * Remove use of `source_text()` on stable since currently it gives the source text of only one token tree.
 
 v0.3.10 - 2023-02-14:
   * Replace unmaintained `atty` dependency with `is-terminal`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert2"
-description = "assert!(...) and check!(...) macros inspired by Catch2"
+description = "assert!(...) and check!(...) macros inspired by Catch2, now with diffs!"
 version = "0.3.11"
 license = "BSD-2-Clause"
 authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ categories = ["development-tools::debugging", "development-tools::testing"]
 assert2-macros = { version = "=0.3.11", path = "assert2-macros" }
 yansi = "0.5.0"
 is-terminal = "0.4.3"
+diff = "0.1.13"
 
 [workspace]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # assert2
 
-All-purpose [`assert!(...)`](https://docs.rs/assert2/latest/assert2/macro.assert.html) and [`check!(...)`](https://docs.rs/assert2/latest/assert2/macro.check.html) macros, inspired by [Catch2](https://github.com/catchorg/Catch2).
-There is also a [`debug_assert!(...)`](https://docs.rs/assert2/latest/assert2/macro.debug_assert.html) macro that is disabled on optimized builds by default.
-As cherry on top there is a [`let_assert!(...)`](https://docs.rs/assert2/latest/assert2/macro.let_assert.html) macro that lets you test a pattern while capturing parts of it.
+All-purpose [`assert!(...)`](macro.assert.html) and [`check!(...)`](macro.check.html) macros, inspired by [Catch2](https://github.com/catchorg/Catch2).
+There is also a [`debug_assert!(...)`](macro.debug_assert.html) macro that is disabled on optimized builds by default.
+As cherry on top there is a [`let_assert!(...)`](macro.let_assert.html) macro that lets you test a pattern while capturing parts of it.
 
 ## Why these macros?
 
 These macros offer some benefits over the assertions from the standard library:
   * The macros parse your expression to detect comparisons and adjust the error message accordingly.
-    No more `assert_eq` or `assert_ne`, just write `assert!(1 + 1 == 2)`, or even `assert!(1 + 1 > 1)`!
+    No more `assert_eq!(a, b)` or `assert_ne!(c, d)`, just write `assert!(1 + 1 == 2)`, or even `assert!(1 + 1 > 1)`!
   * You can test for pattern matches: `assert!(let Err(_) = File::open("/non/existing/file"))`.
   * You can capture parts of the pattern for further testing by using the `let_assert!(...)` macro.
   * The `check` macro can be used to perform multiple checks before panicking.
-  * The macros provide more information when the assertion fails.
-  * Colored failure messages!
+  * The macros provide more information than the standard `std::assert!()` when the assertion fails.
+  * Colored failure messages with diffs!
 
 The macros also accept additional arguments for a custom message, so it is fully compatible with `std::assert`.
-That means you don't have to worry about overwriting the standard `assert` with `use assert2::assert`.
+This means that you can import the macro as a drop in replacement:
+```rust
+use assert2::assert;
+```
 
 ## Examples
 
@@ -24,15 +27,23 @@ That means you don't have to worry about overwriting the standard `assert` with 
 check!(6 + 1 <= 2 * 3);
 ```
 
-![Assertion error](https://github.com/de-vri-es/assert2-rs/raw/2db44c46e4580ec87d2881a698815e1ec5fcdf3f/binary-operator.png)
+![Output](https://raw.githubusercontent.com/de-vri-es/assert2-rs/ba98984a32d6381e6710e34eb1fb83e65e851236/binary-operator.png)
 
 ----------
 
 ```rust
-check!(true && false);
+check!(scrappy == coco);
 ```
 
-![Assertion error](https://github.com/de-vri-es/assert2-rs/raw/2db44c46e4580ec87d2881a698815e1ec5fcdf3f/boolean-expression.png)
+![Output](https://raw.githubusercontent.com/de-vri-es/assert2-rs/54ee3141e9b23a0d9038697d34f29f25ef7fe810/multiline-diff.png)
+
+----------
+
+```rust
+check!((3, Some(4)) == [1, 2, 3].iter().size_hint());
+```
+
+![Output](https://raw.githubusercontent.com/de-vri-es/assert2-rs/54ee3141e9b23a0d9038697d34f29f25ef7fe810/single-line-diff.png)
 
 ----------
 
@@ -40,7 +51,7 @@ check!(true && false);
 check!(let Ok(_) = File::open("/non/existing/file"));
 ```
 
-![Assertion error](https://github.com/de-vri-es/assert2-rs/raw/2db44c46e4580ec87d2881a698815e1ec5fcdf3f/pattern-match.png)
+![Output](https://raw.githubusercontent.com/de-vri-es/assert2-rs/54ee3141e9b23a0d9038697d34f29f25ef7fe810/pattern-match.png)
 
 ----------
 
@@ -48,7 +59,8 @@ check!(let Ok(_) = File::open("/non/existing/file"));
 let_assert!(Err(e) = File::open("/non/existing/file"));
 check!(e.kind() == ErrorKind::PermissionDenied);
 ```
-![Assertion error](https://github.com/de-vri-es/assert2-rs/raw/573a686d1f19e0513cb235df38d157defdadbec0/let-assert.png)
+
+![Output](https://github.com/de-vri-es/assert2-rs/blob/54ee3141e9b23a0d9038697d34f29f25ef7fe810/let-assert.png?raw=true)
 
 ## `assert` vs `check`
 The crate provides two macros: `check!(...)` and `assert!(...)`.
@@ -68,7 +80,7 @@ On stable and beta, it falls back to stringifying the expression.
 This makes the output a bit more readable on nightly.
 
 ## The `let_assert!()` macro
-You can also use the [`let_assert!(...)`](https://docs.rs/assert2/latest/assert2/macro.let_assert.html).
+You can also use the [`let_assert!(...)`](macro.let_assert.html).
 It is very similar to `assert!(let ...)`,
 but all placeholders will be made available as variables in the calling scope.
 
@@ -85,12 +97,25 @@ check!(e.name() == "bogus name");
 check!(e.to_string() == "invalid name: bogus name");
 ```
 
+## Controlling the output format.
 
-## Controlling colored output.
+As an end-user, you can influence the way that `assert2` formats failed assertions by changing the `ASSERT2` environment variable.
+You can specify any combination of options, separated by a comma.
+The supported options are:
+* `auto`: Automatically select the compact or pretty `Debug` format for an assertion based on the length (default).
+* `pretty`: Always use the pretty `Debug` format for assertion messages (`{:#?}`).
+* `compact`: Always use the compact `Debug` format for assertion messages (`{:?}`).
+* `no-color`: Disable colored output, even when the output is going to a terminal.
+* `color`: Enable colored output, even when the output is not going to a terminal.
 
-Colored output can be controlled using environment variables,
-as per the [clicolors spec](https://bixense.com/clicolors/):
+For example, you can run the following command to force the use of the compact `Debug` format with colored output:
+```shell
+ASSERT2=compact,color cargo test
+```
 
- * `CLICOLOR != 0`: ANSI colors are supported and should be used when the program isn't piped.
- * `CLICOLOR == 0`: Don't output ANSI color escape codes.
- * `CLICOLOR_FORCE != 0`: ANSI colors should be enabled no matter what.
+If neither the `color` or the `no-color` options are set,
+then `assert2` follows the [clicolors specification](https://bixense.com/clicolors/):
+
+ * `NO_COLOR != 0` or `CLICOLOR == 0`: Write plain output without color codes.
+ * `CLICOLOR != 0`: Write colored output when the output is going to a terminal.
+ * `CLICOLOR_FORCE != 0`:  Write colored output even when it is not going to a terminal.

--- a/examples/images.rs
+++ b/examples/images.rs
@@ -24,17 +24,17 @@ fn main() {
 	let scrappy = Pet {
 		name: "Scrappy".into(),
 		age: 7,
-		kind: "Bearded Collies".into(),
+		kind: "Bearded Collie".into(),
 		shaved: false,
 	};
 
 	let coco = Pet {
 		name: "Coco".into(),
 		age: 7,
-		kind: "Bearded Collies".into(),
+		kind: "Bearded Collie".into(),
 		shaved: true,
 	};
 	check!(scrappy == coco);
 
-	check!(Some(1) == Some(11));
+	check!((3, Some(4)) == [1, 2, 3].iter().size_hint());
 }

--- a/examples/images.rs
+++ b/examples/images.rs
@@ -12,4 +12,25 @@ fn main() {
 
 	let_assert!(Err(e) = File::open("/non/existing/file"));
 	check!(e.kind() == ErrorKind::PermissionDenied);
+
+	#[derive(Debug, Eq, PartialEq)]
+	struct Foo {
+		lorum: &'static str,
+		ipsum: i32,
+		dolor: Result<&'static str, ()>,
+	}
+
+	let a = Foo {
+		lorum: "Hello world!",
+		ipsum: 42,
+		dolor: Ok("hey"),
+	};
+
+	let b = Foo {
+		lorum: "Hello wrold!",
+		ipsum: 42,
+		dolor: Ok("hey ho"),
+	};
+
+	check!(a == b);
 }

--- a/examples/images.rs
+++ b/examples/images.rs
@@ -14,23 +14,27 @@ fn main() {
 	check!(e.kind() == ErrorKind::PermissionDenied);
 
 	#[derive(Debug, Eq, PartialEq)]
-	struct Foo {
-		lorum: &'static str,
-		ipsum: i32,
-		dolor: Result<&'static str, ()>,
+	struct Pet {
+		name: String,
+		age: u32,
+		kind: String,
+		shaved: bool,
 	}
 
-	let a = Foo {
-		lorum: "Hello world!",
-		ipsum: 42,
-		dolor: Ok("hey"),
+	let scrappy = Pet {
+		name: "Scrappy".into(),
+		age: 7,
+		kind: "Bearded Collies".into(),
+		shaved: false,
 	};
 
-	let b = Foo {
-		lorum: "Hello wrold!",
-		ipsum: 42,
-		dolor: Ok("hey ho"),
+	let coco = Pet {
+		name: "Coco".into(),
+		age: 7,
+		kind: "Bearded Collies".into(),
+		shaved: true,
 	};
+	check!(scrappy == coco);
 
-	check!(a == b);
+	check!(Some(1) == Some(11));
 }

--- a/src/__assert2_impl/print/options.rs
+++ b/src/__assert2_impl/print/options.rs
@@ -1,0 +1,172 @@
+/// End-user configurable options for `assert2`.
+#[derive(Copy, Clone)]
+pub struct AssertOptions {
+	/// The expansion format for variables.
+	pub expand: ExpansionFormat,
+
+	/// If true, use colors in the output.
+	pub color: bool,
+}
+
+impl AssertOptions {
+	/// Get the global options for `assert2`.
+	///
+	/// The default format is `ExpansionFormat::Auto`.
+	/// This can be overridden by adding the `pretty` or `compact` option to the `ASSERT2` environment variable.
+	///
+	/// By default, colored output is enabled if `stderr` is conntected to a terminal.
+	/// If the `CLICOLOR` environment variable is set to `0`, colored output is disabled by default.
+	/// If the `CLICOLOR_FORCE` environment variable is set to something other than `0`,
+	/// color is enabled by default, even if `stderr` is not connected to a terminal.
+	/// The `color` and `no-color` options in the `ASSERT2` environment variable unconditionally enable and disable colored output.
+	///
+	/// Multiple options can be combined in the `ASSERT2` environment variable by separating them with a comma.
+	/// Whitespace around the comma is ignored.
+	/// For example: `ASSERT2=color,pretty` to force colored output and the pretty debug format.
+	///
+	pub fn get() -> AssertOptions {
+		use std::sync::RwLock;
+
+		static STYLE: RwLock<Option<AssertOptions>> = RwLock::new(None);
+		loop {
+			// If it's already initialized, just return it.
+			if let Some(style) = *STYLE.read().unwrap() {
+				return style;
+			}
+
+			// Style wasn't set yet, so try to get a write lock to initialize the style.
+			match STYLE.try_write() {
+				// If we fail to get a write lock, another thread is already initializing the style,
+				// so we just loop back to the start of the function and try the read lock again.
+				Err(_) => continue,
+
+				// If we get the write lock it is up to use to initialize the style.
+				Ok(mut style) => {
+					let style = style.get_or_insert_with(AssertOptions::from_env);
+					if style.color {
+						yansi::Paint::enable()
+					} else {
+						yansi::Paint::disable()
+					}
+					return *style;
+				},
+			}
+		}
+	}
+
+	/// Parse the options from the `ASSERT2` environment variable.
+	fn from_env() -> Self {
+		// If there is no valid `ASSERT2` environment variable, default to an empty string.
+		let format = std::env::var_os("ASSERT2");
+		let format = format.as_ref()
+			.and_then(|x| x.to_str())
+			.unwrap_or("");
+
+		// Start with the defaults.
+		let mut output = Self {
+			expand: ExpansionFormat::Auto,
+			color: should_color(),
+		};
+
+		// And modify them based on the options in the environment variables.
+		for word in format.split(',') {
+			let word = word.trim();
+			if word.eq_ignore_ascii_case("pretty") {
+				output.expand = ExpansionFormat::Pretty;
+			} else if word.eq_ignore_ascii_case("compact") {
+				output.expand = ExpansionFormat::Compact;
+			} else if word.eq_ignore_ascii_case("color") {
+				output.color = true;
+			} else if word.eq_ignore_ascii_case("no-color") {
+				output.color = false;
+			}
+		}
+
+		output
+	}
+}
+
+/// The expansion format for `assert2`.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum ExpansionFormat {
+	/// Automatically choose compact or pretty output depending on the values.
+	///
+	/// If the compact debug format for all involved variables is short enough, the compact format is used.
+	/// Otherwise, all variables are expanded using the pretty debug format.
+	Auto,
+
+	/// Expand variables using the pretty debug format (as with `format!("{:#?}", ..."`).
+	Pretty,
+
+	/// Expand variables using the compact debug format (as with `format!("{:?}", ..."`).
+	Compact,
+}
+
+impl ExpansionFormat {
+	/// Check if the format forces the pretty debug format.
+	pub fn force_pretty(self) -> bool {
+		self == Self::Pretty
+	}
+
+	/// Check if the format forces the compact debug format.
+	pub fn force_compact(self) -> bool {
+		self == Self::Compact
+	}
+
+	/// Expand all items according to the style.
+	pub fn expand_all<const N: usize>(self, values: [&dyn std::fmt::Debug; N]) -> [String; N] {
+		if !self.force_pretty() {
+			let expanded = values.map(|x| format!("{x:?}"));
+			if self.force_compact() ||  Self::is_compact_good(&expanded) {
+				return expanded
+			}
+		}
+		values.map(|x| format!("{x:#?}"))
+	}
+
+	/// Heuristicly determine if a compact debug representation is good for all expanded items.
+	pub fn is_compact_good(expanded: &[impl AsRef<str>]) -> bool {
+		for value in expanded {
+			if value.as_ref().len() > 40 {
+				return false;
+			}
+		}
+		for value in expanded {
+			if value.as_ref().contains('\n') {
+				return false;
+			}
+		}
+		true
+	}
+
+}
+
+/// Check if the clicolors spec thinks we should use colors.
+fn should_color() -> bool {
+	use std::ffi::OsStr;
+
+	/// Check if an environment variable has a false-like value.
+	///
+	/// Returns `false` if the variable is empty.
+	fn is_false(value: impl AsRef<OsStr>) -> bool {
+		let value = value.as_ref();
+		value == "0" || value.eq_ignore_ascii_case("false") || value.eq_ignore_ascii_case("no")
+	}
+
+	fn is_true(value: impl AsRef<OsStr>) -> bool {
+		let value = value.as_ref();
+		value == "1" || value.eq_ignore_ascii_case("true") || value.eq_ignore_ascii_case("yes")
+	}
+
+	#[allow(clippy::if_same_then_else)] // shut up clippy
+	if std::env::var_os("NO_COLOR").is_some_and(is_true) {
+		false
+	} else if std::env::var_os("CLICOLOR").is_some_and(is_false) {
+		false
+	} else if std::env::var_os("CLICOLOR_FORCE").is_some_and(is_true) {
+		true
+	} else {
+		use is_terminal::IsTerminal;
+		std::io::stderr().is_terminal()
+	}
+}


### PR DESCRIPTION
This PR adds diffs to the output of `assert2` \o/

This should help to easily see what the difference between two values really is.

It also changes the default behaviour to automatically choose between the compact or pretty `Debug` format based on the size of the compact format. This can be overridden on the command line by setting `ASSERT2=compact` or `ASSERT2=pretty`.

![multiline-diff](https://github.com/de-vri-es/assert2-rs/assets/786213/7cafa1af-a605-41b1-b7d5-dcfbbdf4663c)

![single-line-diff](https://github.com/de-vri-es/assert2-rs/assets/786213/8b6d4687-cfd4-45fa-a3d2-a3c2b60d39fe)
