### PR TITLE
Tweak suppresion of word highlighting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+main:
+  * Suppress highlighting when diff contains consecutive changed lines.
+  * Make suppression of highlighting based on number of non-highlighted characters more conservative.
+
 v0.3.12 - 2024-02-17:
   * Automatically choose between pretty or compact `Debug` output, unless overridden.
   * Print a diff for failed binary comparisons.


### PR DESCRIPTION
This PR changes the way word highlighting is suppressed:

First, only a sequence of `(left, right)` will get word highlighting. A sequence of `(left left right)` or `(left right right)` will no longer be used for word highlighting.

As a consequence, the suppression of word highlighting based on the number of non-highlighted characters can be made more strict. Instead of suppressing it when highlighting is more than 1/3 of the line, it is now suppressed when highlighting is more than 2/3 of the line.

Open issues:
 * The decision for highlight suppression takes into account unhighlighted whitespace too.
 * It would be nice to try and turn sequences of `left, left, left, right, right, right` into `left, right, left, right, left right` if it results in small word diffs.