### PR TITLE
Proof of Concept: custom scope for `check!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,16 @@ macro_rules! check {
 	}
 }
 
+#[macro_export]
+macro_rules! check_ctx {
+	($ctx:expr, $($tokens:tt)*) => {
+		if let Err(()) = $crate::__assert2_impl::check_impl!($crate, "assert", $($tokens)*) {
+			let ctx: &$crate::CheckContext = $ctx;
+			ctx.set_fail();
+		}
+	};
+}
+
 /// Assert that an expression evaluates to true or matches a pattern.
 ///
 /// This macro supports the same checks as [`assert`](macro.assert.html), but they are only executed if debug assertions are enabled.
@@ -338,3 +348,61 @@ macro_rules! __assert2_stringify {
 
 #[doc(hidden)]
 pub use core::stringify as __assert2_core_stringify;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+pub struct CheckContext {
+	check_failed: AtomicBool
+}
+
+impl CheckContext {
+	pub fn new() -> Self {
+		Self {
+			check_failed: AtomicBool::new(false)
+		}
+	}
+
+	pub fn set_fail(&self) {
+		self.check_failed.store(true, Ordering::Release);
+	}
+}
+
+impl Drop for CheckContext {
+	fn drop(&mut self) {
+		if self.check_failed.load(Ordering::Acquire) {
+			panic!("check failed")
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn test_check_in_loop() {
+		let ctx = CheckContext::new();
+		for i in 0..6 {
+			check_ctx!(&ctx, i%2 == 0, "Check failed for i={i}");
+		}
+	}
+	
+	#[test]
+	fn test_check_nested() {
+		let ctx = CheckContext::new();
+
+		let value = 123;
+
+		assert_something(&ctx, value);
+	
+		assert_more_things(&ctx, value);
+	}
+
+	fn assert_something(ctx: &CheckContext, i: isize) {
+		check_ctx!(ctx, i > 200);
+	}
+
+	fn assert_more_things(ctx: &CheckContext, i: isize) {
+		check_ctx!(ctx, i % 2 == 0);
+	}
+}
+


### PR DESCRIPTION
I use `assert2::check!` a lot in my tests, but was missing some flexibility. Especially when using `check!` in a loop, there's currently no way to prevent panicking after the first iteration in which the check fails. I read https://github.com/de-vri-es/assert2-rs/issues/23 and had a slightly different idea that I successfully tried out:

This PR contains the proof of concept of that idea. I've introduced a `CheckContext` type that tracks whether a check failed and panics when it goes out of scope. This context can be used in the new macro `check_ctx!`. I've also written two tests that show how these two items can be used. This is the output generated by these tests:

```
running 3 tests
test __assert2_impl::print::diff::test_div_ceil ... ok
test test::test_check_in_loop ... FAILED
test test::test_check_nested ... FAILED

failures:

---- test::test_check_in_loop stdout ----
Assertion failed at src/lib.rs:385:4:
  assert!( i % 2 == 0 )
with expansion:
  1 == 0
with message:
  Check failed for i=1

Assertion failed at src/lib.rs:385:4:
  assert!( i % 2 == 0 )
with expansion:
  1 == 0
with message:
  Check failed for i=3

Assertion failed at src/lib.rs:385:4:
  assert!( i % 2 == 0 )
with expansion:
  1 == 0
with message:
  Check failed for i=5

thread 'test::test_check_in_loop' panicked at src/lib.rs:372:13:
check failed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- test::test_check_nested stdout ----
Assertion failed at src/lib.rs:401:3:
  assert!( i > 200 )
with expansion:
  123 > 200

Assertion failed at src/lib.rs:405:3:
  assert!( i % 2 == 0 )
with expansion:
  1 == 0

thread 'test::test_check_nested' panicked at src/lib.rs:372:13:
check failed


failures:
    test::test_check_in_loop
    test::test_check_nested

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `--lib`
```

I quite like the approach and I think that it's even possible to add support for passing a context to the existing `check!` macro. 

What do you think? Could you see something like this in `assert2`?