### PR TITLE
Do not use `terminal_size` on non-supported platforms.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,24 @@ jobs:
         run: |
           rustup install ${{ matrix.rust }} --profile minimal
           rustup default ${{ matrix.rust }}
-      - name: Build
-        run: cargo build --release --all-features --color=always
-      - name: Test
-        run: cargo test --release --all-features --color=always
+      - name: cargo build
+        run: cargo build --release --all-features --all-targets --color=always
+      - name: cargo test
+        run: cargo test --release --all-features --all-targets --color=always
+  check:
+    name:  check-only ${{ matrix.target }}, rust-${{ matrix.rust }}
+    strategy:
+      matrix:
+        target: [wasm32-unknown-unknown]
+        rust: [stable, nightly, 1.71.0]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Install Rust ${{ matrix.rust }} target ${{ matrix.target }}
+        run: |
+          rustup install ${{ matrix.rust }} --profile minimal
+          rustup default ${{ matrix.rust }}
+          rustup target add ${{ matrix.target }}
+      - name: cargo check
+        run: cargo check --release --all-features --all-targets --color=always --target ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+main:
+  * Fix compilation on non-Unix and non-Windows platforms.
+
 v0.3.17 - 2026-02-15:
   * Support `let` chains in assertions.
   * Split top-level `&&` expressions, and highlight which one failed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ assert2-macros = { version = "=0.3.17", path = "assert2-macros" }
 yansi = "1.0.1"
 diff = "0.1.13"
 unicode-width = "0.2.1"
+
+[target.'cfg(any(unix, windows))'.dependencies]
 terminal_size = "0.4.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Should fix #46, atleast short term.

We probably still need to deal better with unknown terminal width, especially for the new underlining feature. Current solution forces a maximum width of `80`, which may be sub-optimal if much more space is available, and render wrong when the true maximum is lower.